### PR TITLE
Only request missing entries from device.

### DIFF
--- a/lib/device_screen.dart
+++ b/lib/device_screen.dart
@@ -141,12 +141,12 @@ class _DeviceScreenState extends State<DeviceScreen> {
 
   Future updateData() async {
     try {
-      // TODO(smoser): Are fetches below 50 not allowed?
-      final int numEntries = math.max(
-        50,
-        _sensorHistory?.missingEntriesSince(DateTime.now()) ?? 5000,
-      );
+      final int numEntries =
+          _sensorHistory?.missingEntriesSince(DateTime.now()) ?? 5000;
       await initBluetooth();
+      // Get config first to wake up device. If this is not done, getMemoryData
+      // occasionally only returns partial data.
+      await _bluetoothManager.getConfig();
       final newEntries = await _bluetoothManager.getMemoryData(numEntries, (
         update,
       ) {

--- a/lib/device_screen.dart
+++ b/lib/device_screen.dart
@@ -141,8 +141,11 @@ class _DeviceScreenState extends State<DeviceScreen> {
 
   Future updateData() async {
     try {
-      final int numEntries =
-          _sensorHistory?.missingEntriesSince(DateTime.now()) ?? 5000;
+      // TODO(smoser): Are fetches below 50 not allowed?
+      final int numEntries = math.max(
+        50,
+        _sensorHistory?.missingEntriesSince(DateTime.now()) ?? 5000,
+      );
       await initBluetooth();
       final newEntries = await _bluetoothManager.getMemoryData(numEntries, (
         update,

--- a/lib/device_screen.dart
+++ b/lib/device_screen.dart
@@ -141,14 +141,18 @@ class _DeviceScreenState extends State<DeviceScreen> {
 
   Future updateData() async {
     try {
+      final int numEntries =
+          _sensorHistory?.missingEntriesSince(DateTime.now()) ?? 5000;
       await initBluetooth();
-      final newEntries = await _bluetoothManager.getMemoryData((update) {
+      final newEntries = await _bluetoothManager.getMemoryData(numEntries, (
+        update,
+      ) {
         _statusUpdates.add(update);
         if (mounted) {
           setState(() {});
         }
       });
-      _sensorHistory = SensorHistory(sensorEntries: newEntries);
+      _sensorHistory = SensorHistory.createUpdated(_sensorHistory, newEntries);
       _statusUpdates.add('Got sensor history: $_sensorHistory');
       _preferences.then((p) {
         final encodedEntries = _sensorHistory!.toBase64ProtoString();

--- a/lib/device_screen.dart
+++ b/lib/device_screen.dart
@@ -245,6 +245,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
           title: _buildTitle(),
           actions: [
             IconButton(
+              tooltip: "Fix Time on device",
               onPressed: () => getAndFixTime(),
               icon: IconCraft(
                 Icon(Icons.schedule),

--- a/lib/device_screen.dart
+++ b/lib/device_screen.dart
@@ -143,6 +143,13 @@ class _DeviceScreenState extends State<DeviceScreen> {
     try {
       final int numEntries =
           _sensorHistory?.missingEntriesSince(DateTime.now()) ?? 5000;
+      if (numEntries == 0) {
+        _statusUpdates.add('No missing entries.');
+        if (mounted) {
+          setState(() {});
+        }
+        return;
+      }
       await initBluetooth();
       // Get config first to wake up device. If this is not done, getMemoryData
       // occasionally only returns partial data.

--- a/lib/device_screen.dart
+++ b/lib/device_screen.dart
@@ -153,7 +153,11 @@ class _DeviceScreenState extends State<DeviceScreen> {
       await initBluetooth();
       // Get config first to wake up device. If this is not done, getMemoryData
       // occasionally only returns partial data.
-      await _bluetoothManager.getConfig();
+      try {
+        await _bluetoothManager.getConfig();
+      } on TimeoutException {
+        _statusUpdates.add('Get config timed out, ignoring...');
+      }
       final newEntries = await _bluetoothManager.getMemoryData(numEntries, (
         update,
       ) {

--- a/lib/scan_screen.dart
+++ b/lib/scan_screen.dart
@@ -57,6 +57,7 @@ class _ScanScreenState extends ConsumerState<ScanScreen> {
 
   @override
   void dispose() {
+    FlutterBluePlus.stopScan();
     _scanResultsSubscription.cancel();
     _isScanningSubscription.cancel();
     super.dispose();
@@ -102,14 +103,6 @@ class _ScanScreenState extends ConsumerState<ScanScreen> {
     }
   }
 
-  Future onStopPressed() async {
-    try {
-      FlutterBluePlus.stopScan();
-    } catch (e) {
-      log('Stop scan failed: $e');
-    }
-  }
-
   void onOpenPressed(BluetoothDevice btDevice) {
     KnownDevice.add(ref, btDevice).then((_) {
       log('Added to $btDevice known devices');
@@ -131,10 +124,7 @@ class _ScanScreenState extends ConsumerState<ScanScreen> {
 
   Widget _buildScanButton(BuildContext context) {
     if (FlutterBluePlus.isScanningNow) {
-      return FloatingActionButton(
-        onPressed: onStopPressed,
-        child: const Icon(Icons.stop),
-      );
+      return SizedBox();
     } else {
       return FloatingActionButton(
         onPressed: onScanPressed,

--- a/lib/scan_screen.dart
+++ b/lib/scan_screen.dart
@@ -68,9 +68,7 @@ class _ScanScreenState extends ConsumerState<ScanScreen> {
       // https://github.com/pvvx/ATC_MiThermometer?tab=readme-ov-file#control-function-id-when-connected;
       // Note that using those as service list does not work.
       // If this is specified on Android, the plugin throws an exception.
-      return [
-        BluetoothConstants.memoServiceGuid,
-      ];
+      return [BluetoothConstants.memoServiceGuid];
     }
     return [];
   }

--- a/lib/services/bluetooth_commands.dart
+++ b/lib/services/bluetooth_commands.dart
@@ -3,6 +3,12 @@ import 'dart:typed_data';
 import 'package:mi_thermo_reader/services/bluetooth_constants.dart';
 
 class BluetoothCommands {
+  static List<int> getConfigCommand() {
+    final request = Uint8List(1).buffer.asByteData();
+    request.setUint8(0, BluetoothConstants.commandConfigBlk);
+    return request.buffer.asUint8List();
+  }
+
   /// numMemos is the number of entries to retrieve from memory, starting with the most recent entry.
   static List<int> getMemoCommand(int numMemos) {
     // Send command to read memory measures.

--- a/lib/services/bluetooth_constants.dart
+++ b/lib/services/bluetooth_constants.dart
@@ -7,6 +7,7 @@ class BluetoothConstants {
 
   static const commandTimeBlk = 0x23;
   static const commandMemoBlk = 0x35;
+  static const commandConfigBlk = 0x55;
 
   // See https://bthome.io/format/
   static final btHomeReversedGuid = Guid("fcd2");

--- a/lib/services/bluetooth_manager.dart
+++ b/lib/services/bluetooth_manager.dart
@@ -4,7 +4,7 @@ import 'package:collection/collection.dart';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 import 'package:mi_thermo_reader/services/bluetooth_commands.dart';
 import 'package:mi_thermo_reader/services/bluetooth_constants.dart';
-import 'package:mi_thermo_reader/services/memo_service_processor.dart';
+import 'package:mi_thermo_reader/services/memo_command_processor.dart';
 import 'package:mi_thermo_reader/services/time_command_processor.dart';
 import 'package:mi_thermo_reader/utils/sensor_entry.dart';
 
@@ -52,7 +52,7 @@ class BluetoothManager {
     if (_characteristic == null) {
       throw "Not initialized";
     }
-    final processor = MemoServiceProcessor(statusUpdate: statusUpdate);
+    final processor = MemoCommandProcessor(statusUpdate: statusUpdate);
     final valueSubscription = _characteristic!.onValueReceived.listen(
       processor.onData,
       onError: processor.onError,

--- a/lib/services/bluetooth_manager.dart
+++ b/lib/services/bluetooth_manager.dart
@@ -48,7 +48,7 @@ class BluetoothManager {
     statusUpdate('Subscribed to notifications');
   }
 
-  Future<List<SensorEntry>> getMemoryData(Function(String) statusUpdate) async {
+  Future<List<SensorEntry>> getMemoryData(int numEntries, Function(String) statusUpdate) async {
     if (_characteristic == null) {
       throw "Not initialized, characteristic is missing.";
     }
@@ -60,10 +60,10 @@ class BluetoothManager {
     device.cancelWhenDisconnected(valueSubscription);
 
     await _characteristic!.write(
-      BluetoothCommands.getMemoCommand(5000),
+      BluetoothCommands.getMemoCommand(numEntries),
       withoutResponse: true,
     );
-    statusUpdate("Start get memo: Success");
+    statusUpdate("Start get memo($numEntries): Success");
 
     try {
       final result = await processor.waitForResults();

--- a/lib/services/bluetooth_manager.dart
+++ b/lib/services/bluetooth_manager.dart
@@ -65,10 +65,12 @@ class BluetoothManager {
     );
     statusUpdate("Start get memo: Success");
 
-    final result = await processor.waitForResults();
-    valueSubscription.cancel();
-
-    return result;
+    try {
+      final result = await processor.waitForResults();
+      return result;
+    } finally {
+      valueSubscription.cancel();
+    }
   }
 
   Future<Duration> getDeviceTimeAndDrift() async {

--- a/lib/services/bluetooth_manager.dart
+++ b/lib/services/bluetooth_manager.dart
@@ -71,9 +71,10 @@ class BluetoothManager {
   }
 
   Future getConfig() async {
-    return _execute([
-      BluetoothConstants.commandConfigBlk,
-    ], ConfigCommandProcessor());
+    return _execute(
+      BluetoothCommands.getConfigCommand(),
+      ConfigCommandProcessor(),
+    );
   }
 
   Future<List<SensorEntry>> getMemoryData(

--- a/lib/services/bluetooth_manager.dart
+++ b/lib/services/bluetooth_manager.dart
@@ -50,7 +50,7 @@ class BluetoothManager {
 
   Future<List<SensorEntry>> getMemoryData(Function(String) statusUpdate) async {
     if (_characteristic == null) {
-      throw "Not initialized";
+      throw "Not initialized, characteristic is missing.";
     }
     final processor = MemoCommandProcessor(statusUpdate: statusUpdate);
     final valueSubscription = _characteristic!.onValueReceived.listen(

--- a/lib/services/bluetooth_manager.dart
+++ b/lib/services/bluetooth_manager.dart
@@ -82,6 +82,7 @@ class BluetoothManager {
     Function(String) statusUpdate,
   ) async {
     final processor = MemoCommandProcessor(statusUpdate: statusUpdate);
+    statusUpdate('Requesting $numEntries from memory');
     return _execute(BluetoothCommands.getMemoCommand(numEntries), processor);
   }
 

--- a/lib/services/bluetooth_manager.dart
+++ b/lib/services/bluetooth_manager.dart
@@ -4,6 +4,8 @@ import 'package:collection/collection.dart';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 import 'package:mi_thermo_reader/services/bluetooth_commands.dart';
 import 'package:mi_thermo_reader/services/bluetooth_constants.dart';
+import 'package:mi_thermo_reader/services/command_processor.dart';
+import 'package:mi_thermo_reader/services/config_command_processor.dart';
 import 'package:mi_thermo_reader/services/memo_command_processor.dart';
 import 'package:mi_thermo_reader/services/time_command_processor.dart';
 import 'package:mi_thermo_reader/utils/sensor_entry.dart';
@@ -48,22 +50,17 @@ class BluetoothManager {
     statusUpdate('Subscribed to notifications');
   }
 
-  Future<List<SensorEntry>> getMemoryData(int numEntries, Function(String) statusUpdate) async {
+  Future<T> _execute<T>(List<int> command, CommandProcessor processor) async {
     if (_characteristic == null) {
       throw "Not initialized, characteristic is missing.";
     }
-    final processor = MemoCommandProcessor(statusUpdate: statusUpdate);
     final valueSubscription = _characteristic!.onValueReceived.listen(
       processor.onData,
       onError: processor.onError,
     );
     device.cancelWhenDisconnected(valueSubscription);
 
-    await _characteristic!.write(
-      BluetoothCommands.getMemoCommand(numEntries),
-      withoutResponse: true,
-    );
-    statusUpdate("Start get memo($numEntries): Success");
+    await _characteristic!.write(command, withoutResponse: true);
 
     try {
       final result = await processor.waitForResults();
@@ -73,25 +70,23 @@ class BluetoothManager {
     }
   }
 
+  Future getConfig() async {
+    return _execute([
+      BluetoothConstants.commandConfigBlk,
+    ], ConfigCommandProcessor());
+  }
+
+  Future<List<SensorEntry>> getMemoryData(
+    int numEntries,
+    Function(String) statusUpdate,
+  ) async {
+    final processor = MemoCommandProcessor(statusUpdate: statusUpdate);
+    return _execute(BluetoothCommands.getMemoCommand(numEntries), processor);
+  }
+
   Future<Duration> getDeviceTimeAndDrift() async {
-    if (_characteristic == null) {
-      throw "Not initialized";
-    }
     final processor = TimeCommandProcessor();
-    final valueSubscription = _characteristic!.onValueReceived.listen(
-      processor.onData,
-      onError: processor.onError,
-    );
-
-    await _characteristic!.write(
-      BluetoothCommands.getDeviceTime(),
-      withoutResponse: true,
-    );
-
-    final drift = await processor.waitForResults();
-    valueSubscription.cancel();
-
-    return drift;
+    return _execute(BluetoothCommands.getDeviceTime(), processor);
   }
 
   // Because of time drifts on the device, calling this occasionally is necessary.
@@ -107,7 +102,6 @@ class BluetoothManager {
   }
 
   void dispose() {
-    // TODO(panmari): Should this disconnect? Or keep the connection open if the user returns?
     device.disconnect();
   }
 }

--- a/lib/services/command_processor.dart
+++ b/lib/services/command_processor.dart
@@ -1,0 +1,16 @@
+import 'dart:async';
+
+abstract class CommandProcessor<T> {
+  final done = Completer<T>();
+
+  // Executed when new data from the command is received.
+  void onData(List<int> values);
+
+  void onError(Object error, StackTrace trace) {
+    done.completeError(error, trace);
+  }
+
+  Future<T> waitForResults() {
+    return done.future;
+  }
+}

--- a/lib/services/command_processor.dart
+++ b/lib/services/command_processor.dart
@@ -10,7 +10,9 @@ abstract class CommandProcessor<T> {
     done.completeError(error, trace);
   }
 
+  // Callees should wait for results while data arrives. Note that this might
+  // give a TimeoutException.
   Future<T> waitForResults() {
-    return done.future;
+    return done.future.timeout(Duration(seconds: 30));
   }
 }

--- a/lib/services/command_processor.dart
+++ b/lib/services/command_processor.dart
@@ -2,6 +2,9 @@ import 'dart:async';
 
 abstract class CommandProcessor<T> {
   final done = Completer<T>();
+  final Duration timeout;
+
+  CommandProcessor({this.timeout = const Duration(seconds: 30)});
 
   // Executed when new data from the command is received.
   void onData(List<int> values);
@@ -13,6 +16,6 @@ abstract class CommandProcessor<T> {
   // Callees should wait for results while data arrives. Note that this might
   // give a TimeoutException.
   Future<T> waitForResults() {
-    return done.future.timeout(Duration(seconds: 30));
+    return done.future.timeout(timeout);
   }
 }

--- a/lib/services/config_command_processor.dart
+++ b/lib/services/config_command_processor.dart
@@ -5,6 +5,8 @@ import 'package:mi_thermo_reader/services/bluetooth_constants.dart';
 import 'package:mi_thermo_reader/services/command_processor.dart';
 
 class ConfigCommandProcessor extends CommandProcessor {
+  ConfigCommandProcessor() : super(timeout: Duration(seconds: 5));
+
   @override
   void onData(List<int> values) {
     if (values.isEmpty) {
@@ -12,7 +14,7 @@ class ConfigCommandProcessor extends CommandProcessor {
     }
     final data = ByteData.view(Uint8List.fromList(values).buffer);
     final blkid = data.getUint8(0);
-    log('Got config: $data');
+    log('Got config: $values');
 
     if (blkid == BluetoothConstants.commandConfigBlk) {
       done.complete();

--- a/lib/services/config_command_processor.dart
+++ b/lib/services/config_command_processor.dart
@@ -1,0 +1,9 @@
+import 'package:mi_thermo_reader/services/command_processor.dart';
+
+class ConfigCommandProcessor extends CommandProcessor {
+  @override
+  void onData(List<int> values) {
+
+    // TODO(panmari): Parse interesting bits of config.
+  }
+}

--- a/lib/services/config_command_processor.dart
+++ b/lib/services/config_command_processor.dart
@@ -1,9 +1,21 @@
+import 'dart:developer';
+import 'dart:typed_data';
+
+import 'package:mi_thermo_reader/services/bluetooth_constants.dart';
 import 'package:mi_thermo_reader/services/command_processor.dart';
 
 class ConfigCommandProcessor extends CommandProcessor {
   @override
   void onData(List<int> values) {
+    if (values.isEmpty) {
+      return;
+    }
+    final data = ByteData.view(Uint8List.fromList(values).buffer);
+    final blkid = data.getUint8(0);
+    log('Got config: $data');
 
-    // TODO(panmari): Parse interesting bits of config.
+    if (blkid == BluetoothConstants.commandConfigBlk) {
+      done.complete();
+    }
   }
 }

--- a/lib/services/memo_command_processor.dart
+++ b/lib/services/memo_command_processor.dart
@@ -27,11 +27,6 @@ class MemoCommandProcessor extends CommandProcessor<List<SensorEntry>> {
       return;
     }
     if (data.lengthInBytes >= 3) {
-      // They are sent in reverse chronological order, and might be received out of order.
-      // Plus there might be retries. Be very defensive about keeping each value only once.
-      _sensorEntries.sort((a, b) => a.timestamp.compareTo(b.timestamp));
-      final alreadyPresent = <DateTime>{}; // This is a set.
-      _sensorEntries.retainWhere((e) => alreadyPresent.add(e.timestamp));
       statusUpdate('Done with reading. Got ${_sensorEntries.length} samples');
       done.complete(_sensorEntries);
       return;

--- a/lib/services/memo_command_processor.dart
+++ b/lib/services/memo_command_processor.dart
@@ -1,16 +1,16 @@
-import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:mi_thermo_reader/services/bluetooth_constants.dart';
+import 'package:mi_thermo_reader/services/command_processor.dart';
 import 'package:mi_thermo_reader/utils/sensor_entry.dart';
 
-class MemoServiceProcessor {
+class MemoCommandProcessor extends CommandProcessor<List<SensorEntry>> {
   final Function(String) statusUpdate;
   final _sensorEntries = <SensorEntry>[];
-  final done = Completer<List<SensorEntry>>();
 
-  MemoServiceProcessor({required this.statusUpdate});
+  MemoCommandProcessor({required this.statusUpdate});
 
+  @override
   void onData(List<int> values) {
     if (values.isEmpty) {
       return;
@@ -43,13 +43,5 @@ class MemoServiceProcessor {
       return;
     }
     statusUpdate("data with unexpected size data.lengthInBytes: $data");
-  }
-
-  void onError(Object error, StackTrace trace) {
-    done.completeError(error, trace);
-  }
-
-  Future<List<SensorEntry>> waitForResults() {
-    return done.future;
   }
 }

--- a/lib/services/time_command_processor.dart
+++ b/lib/services/time_command_processor.dart
@@ -1,16 +1,15 @@
-import 'dart:async';
 import 'dart:developer';
 import 'dart:typed_data';
 
 import 'package:mi_thermo_reader/services/bluetooth_constants.dart';
+import 'package:mi_thermo_reader/services/command_processor.dart';
 
-class TimeCommandProcessor {
-  final done = Completer<Duration>();
-
+class TimeCommandProcessor extends CommandProcessor<Duration> {
   DateTime _toDateTime(int timestampSeconds) {
     return DateTime.fromMillisecondsSinceEpoch(timestampSeconds * 1000);
   }
 
+  @override
   void onData(List<int> values) {
     if (values.isEmpty) {
       return;
@@ -40,13 +39,5 @@ class TimeCommandProcessor {
       );
       done.complete(deviceTimeDrift);
     }
-  }
-
-  void onError(Object error, StackTrace trace) {
-    done.completeError(error, trace);
-  }
-
-  Future<Duration> waitForResults() {
-    return done.future;
   }
 }

--- a/lib/utils/sensor_history.dart
+++ b/lib/utils/sensor_history.dart
@@ -34,7 +34,7 @@ class SensorHistory {
     SensorHistory? old,
     List<SensorEntry> newEntries,
   ) {
-    final List<SensorEntry> updated = List.from(old?.sensorEntries ?? []) ;
+    final List<SensorEntry> updated = List.from(old?.sensorEntries ?? []);
     updated.addAll(newEntries);
     // They are sent in reverse chronological order, and might be received out of order.
     // Plus there might be retries. Be very defensive about keeping each value only once.

--- a/lib/utils/sensor_history.dart
+++ b/lib/utils/sensor_history.dart
@@ -34,7 +34,7 @@ class SensorHistory {
     SensorHistory? old,
     List<SensorEntry> newEntries,
   ) {
-    final updated = old?.sensorEntries ?? [];
+    final List<SensorEntry> updated = List.from(old?.sensorEntries ?? []) ;
     updated.addAll(newEntries);
     // They are sent in reverse chronological order, and might be received out of order.
     // Plus there might be retries. Be very defensive about keeping each value only once.

--- a/test/device_screen_test.dart
+++ b/test/device_screen_test.dart
@@ -57,7 +57,7 @@ void main() {
             .onPressed,
         isNotNull,
       );
-      expect(find.byIcon(Icons.safety_check), findsOneWidget);
+      expect(find.byTooltip(RegExp("Fix Time")), findsOneWidget);
       expect(
         find.text("No entries available, click [Update] to fetch data"),
         findsOneWidget,


### PR DESCRIPTION
In order to reduce read time, guesstimate the number of entries missing form history and only request those. Then reassemble the history.