### PR TITLE
Add support for THB2 devices

### DIFF
--- a/lib/services/bluetooth_constants.dart
+++ b/lib/services/bluetooth_constants.dart
@@ -5,6 +5,9 @@ class BluetoothConstants {
   static final memoServiceGuid = Guid("1f10");
   static final memoCharacteristicGuid = Guid("1f1f");
 
+  static final memoServiceTHB2Guid = Guid("fcd2");
+  static final memoCharacteristicTHB2Guid = Guid("fff4");
+
   static const commandTimeBlk = 0x23;
   static const commandMemoBlk = 0x35;
   static const commandConfigBlk = 0x55;

--- a/lib/services/bluetooth_manager.dart
+++ b/lib/services/bluetooth_manager.dart
@@ -31,7 +31,9 @@ class BluetoothManager {
           compatibleServiceUuids.contains(service.serviceUuid),
     );
     if (memoService == null) {
-      throw 'Failed to find compatible service, any of  $compatibleServiceUuids';
+      throw Exception(
+        'Failed to find compatible service, any of  $compatibleServiceUuids',
+      );
     }
     final compatibleCharacteristicUuids = [
       BluetoothConstants.memoCharacteristicGuid,
@@ -41,7 +43,9 @@ class BluetoothManager {
       (c) => compatibleCharacteristicUuids.contains(c.characteristicUuid),
     );
     if (characteristic == null) {
-      throw 'Failed to find compatible characteristic, any of $compatibleCharacteristicUuids.';
+      throw Exception(
+        'Failed to find compatible characteristic, any of $compatibleCharacteristicUuids.',
+      );
     }
     return characteristic;
   }

--- a/lib/widgets/popup_menu.dart
+++ b/lib/widgets/popup_menu.dart
@@ -1,6 +1,7 @@
 import 'dart:developer' as developer;
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
 import 'package:package_info_plus/package_info_plus.dart';
@@ -51,8 +52,45 @@ class _PopupMenuState extends State<PopupMenu> {
                   applicationVersion: snapshot.data?.version ?? 'Unknown',
                   children: [
                     Container(padding: const EdgeInsets.fromLTRB(0, 10, 0, 10)),
-                    const Text(
-                      'After patching your the firmware from https://github.com/pvvx/ATC_MiThermometer, it becomes supercharged with a bunch of great capabilites. Most importantly, it saves sensor values to device in a fixed interval.\n\nMi Thermometer Reader helps with reading and visualizing all data stored on device.\n',
+                    RichText(
+                      text: TextSpan(
+                        style: Theme.of(context).textTheme.bodyMedium,
+                        children: [
+                          const TextSpan(
+                            text:
+                                'After patching your device with the firmware from ',
+                          ),
+                          TextSpan(
+                            text: 'https://github.com/pvvx/ATC_MiThermometer',
+                            style: const TextStyle(color: Colors.lightBlue),
+                            recognizer:
+                                TapGestureRecognizer()
+                                  ..onTap = () {
+                                    launchUrl(
+                                      Uri.parse(
+                                        'https://github.com/pvvx/ATC_MiThermometer',
+                                      ),
+                                    );
+                                  },
+                          ),
+                          const TextSpan(text: ' or '),
+                          TextSpan(
+                            text: 'https://github.com/pvvx/THB2',
+                            style: const TextStyle(color: Colors.lightBlue),
+                            recognizer:
+                                TapGestureRecognizer()
+                                  ..onTap = () {
+                                    launchUrl(
+                                      Uri.parse('https://github.com/pvvx/THB2'),
+                                    );
+                                  },
+                          ),
+                          const TextSpan(
+                            text:
+                                ', it becomes supercharged with a bunch of great capabilites. Most importantly, it saves sensor values to device at fixed intervals.\n\nMi Thermometer Reader helps with reading and visualizing all data stored on the device.\n',
+                          ),
+                        ],
+                      ),
                     ),
                     ElevatedButton(
                       onPressed:

--- a/lib/widgets/popup_menu.dart
+++ b/lib/widgets/popup_menu.dart
@@ -87,7 +87,7 @@ class _PopupMenuState extends State<PopupMenu> {
                           ),
                           const TextSpan(
                             text:
-                                ', it becomes supercharged with a bunch of great capabilites. Most importantly, it saves sensor values to device at fixed intervals.\n\nMi Thermometer Reader helps with reading and visualizing all data stored on the device.\n',
+                                ', it becomes supercharged with a bunch of great capabilities. Most importantly, it saves sensor values to device at fixed intervals.\n\nMi Thermometer Reader helps with reading and visualizing all data stored on the device.\n',
                           ),
                         ],
                       ),


### PR DESCRIPTION
Introduce support for THB2 devices by adding corresponding service and characteristic UUIDs. Update the "about" dialog to mention both compatible firmwares and make URLs clickable.